### PR TITLE
Add alert digest scheduling and email notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - Added regression tests covering RBAC permission enforcement and scoped domain/report access.
 - Added RDAP ownership metadata, Spamhaus DNSBL insights, and SANS ISC reputation scoring to the `ip_intelligence` cache with a forward migration script.
 - Implemented a reusable DNS-over-HTTPS client and accompanying tests to back DMARC/SPF/DKIM validation and Spamhaus lookups.
+- Implemented Spectre-based alert rule management, incident tracking, and rule creation views with CSRF-aware forms.
+- Added reusable HTML email templates for alert incidents, digest schedules, and ad-hoc report sends.
+- Built a digest scheduling controller/UI with supporting tests covering automated dispatch and mailer mocking.
 
 ### Changed
 - Updated documentation to explain the dual Composer environments and new directory structure.
@@ -18,3 +21,4 @@ All notable changes to this project will be documented in this file.
 - Updated the dashboard view to read the username from the session with HTML escaping and a neutral fallback label.
 - Enforced RBAC permission checks on privileged controllers and filtered domain/group/report queries to the current user's accessible assignments.
 - Enhanced the report detail view and GeoIP service to surface RDAP contacts, DNSBL status, and reputation signals for each source IP.
+- Updated alert processing to reuse a dedicated service, expanded cron automation with alert and digest jobs, and enabled email delivery through templated mailer calls.

--- a/root/app/Controllers/AlertController.php
+++ b/root/app/Controllers/AlertController.php
@@ -7,6 +7,7 @@ use App\Models\Alert;
 use App\Models\DomainGroup;
 use App\Models\Domain;
 use App\Core\RBACManager;
+use App\Services\AlertService;
 
 /**
  * Alert Controller for managing real-time alerting system
@@ -160,12 +161,7 @@ class AlertController extends Controller
      */
     private function testAlerts(): void
     {
-        $incidents = Alert::checkAlertRules();
-        
-        // Send notifications for any triggered incidents
-        foreach ($incidents as $incident) {
-            Alert::sendNotifications($incident['incident_id']);
-        }
+        AlertService::runAlertChecks();
     }
 
     /**

--- a/root/app/Controllers/EmailDigestController.php
+++ b/root/app/Controllers/EmailDigestController.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Core\Controller;
+use App\Core\RBACManager;
+use App\Helpers\MessageHelper;
+use App\Models\Domain;
+use App\Models\DomainGroup;
+use App\Models\EmailDigest;
+use DateInterval;
+use DateTimeImmutable;
+use Throwable;
+
+/**
+ * Controller responsible for managing scheduled email digests.
+ */
+class EmailDigestController extends Controller
+{
+    /**
+     * Display the digest schedule management view.
+     */
+    public function handleRequest(): void
+    {
+        RBACManager::getInstance()->requirePermission(RBACManager::PERM_MANAGE_ALERTS);
+
+        $this->data = [
+            'schedules' => EmailDigest::getAllSchedules(),
+            'domains' => Domain::getAllDomains(),
+            'groups' => DomainGroup::getAllGroups(),
+        ];
+
+        require __DIR__ . '/../Views/email_digests.php';
+    }
+
+    /**
+     * Handle form submissions for schedule creation and management.
+     */
+    public function handleSubmission(): void
+    {
+        RBACManager::getInstance()->requirePermission(RBACManager::PERM_MANAGE_ALERTS);
+
+        $action = $_POST['action'] ?? '';
+
+        switch ($action) {
+            case 'create_schedule':
+                $this->createSchedule();
+                break;
+            case 'toggle_schedule':
+                $this->toggleSchedule();
+                break;
+            default:
+                MessageHelper::addMessage('Unsupported digest action requested.', 'error');
+                break;
+        }
+
+        if (defined('PHPUNIT_RUNNING') && PHPUNIT_RUNNING) {
+            return;
+        }
+
+        header('Location: /email-digests');
+        exit();
+    }
+
+    /**
+     * Persist a new digest schedule.
+     */
+    private function createSchedule(): void
+    {
+        $name = trim($_POST['name'] ?? '');
+        $frequencyInput = $_POST['frequency'] ?? 'weekly';
+        $customRangeDays = max(1, (int) ($_POST['custom_range_days'] ?? 7));
+        $recipientsInput = $_POST['recipients'] ?? '';
+        $domainFilter = trim($_POST['domain_filter'] ?? '');
+        $groupFilter = !empty($_POST['group_filter']) ? (int) $_POST['group_filter'] : null;
+        $enabled = isset($_POST['enabled']) ? 1 : 0;
+        $startImmediately = isset($_POST['start_immediately']);
+        $firstSendAt = trim($_POST['first_send_at'] ?? '');
+
+        $recipients = array_values(array_filter(array_map('trim', explode(',', $recipientsInput))));
+
+        if ($name === '' || empty($recipients)) {
+            MessageHelper::addMessage('A schedule name and at least one recipient are required.', 'error');
+            return;
+        }
+
+        $frequency = $frequencyInput === 'custom'
+            ? sprintf('custom:%d', $customRangeDays)
+            : $frequencyInput;
+
+        $nextScheduled = null;
+
+        if ($firstSendAt !== '') {
+            try {
+                $date = new DateTimeImmutable($firstSendAt);
+                $nextScheduled = $date->format('Y-m-d H:i:s');
+            } catch (Throwable $exception) {
+                // Invalid datetime provided; fall back to computed schedule.
+            }
+        }
+
+        if ($nextScheduled === null) {
+            if ($startImmediately) {
+                $nextScheduled = (new DateTimeImmutable('now'))->format('Y-m-d H:i:s');
+            } else {
+                $interval = $this->buildIntervalForFrequency($frequencyInput, $customRangeDays);
+                $nextScheduled = (new DateTimeImmutable('now'))->add($interval)->format('Y-m-d H:i:s');
+            }
+        }
+
+        EmailDigest::createSchedule([
+            'name' => $name,
+            'frequency' => $frequency,
+            'recipients' => $recipients,
+            'domain_filter' => $domainFilter,
+            'group_filter' => $groupFilter,
+            'enabled' => $enabled,
+            'next_scheduled' => $nextScheduled,
+        ]);
+
+        MessageHelper::addMessage('Email digest schedule created successfully.', 'success');
+    }
+
+    /**
+     * Toggle a schedule's enabled state.
+     */
+    private function toggleSchedule(): void
+    {
+        $scheduleId = (int) ($_POST['schedule_id'] ?? 0);
+        $desiredState = ($_POST['desired_state'] ?? '1') === '1';
+
+        if ($scheduleId <= 0) {
+            MessageHelper::addMessage('Invalid schedule specified.', 'error');
+            return;
+        }
+
+        EmailDigest::setEnabled($scheduleId, $desiredState);
+        MessageHelper::addMessage(
+            $desiredState ? 'Schedule enabled.' : 'Schedule disabled.',
+            'success'
+        );
+    }
+
+    /**
+     * Build a DateInterval from a frequency selection.
+     */
+    private function buildIntervalForFrequency(string $frequency, int $customDays): DateInterval
+    {
+        return match ($frequency) {
+            'daily' => new DateInterval('P1D'),
+            'weekly' => new DateInterval('P7D'),
+            'monthly' => new DateInterval('P1M'),
+            'custom' => new DateInterval('P' . max(1, $customDays) . 'D'),
+            default => new DateInterval('P7D'),
+        };
+    }
+}

--- a/root/app/Controllers/ReportsController.php
+++ b/root/app/Controllers/ReportsController.php
@@ -6,6 +6,8 @@ use App\Core\Controller;
 use App\Models\DmarcReport;
 use App\Models\Domain;
 use App\Core\RBACManager;
+use App\Core\Mailer;
+use App\Helpers\MessageHelper;
 
 /**
  * Reports Controller for DMARC report listing and filtering
@@ -84,6 +86,18 @@ class ReportsController extends Controller
     public function handleSubmission(): void
     {
         RBACManager::getInstance()->requirePermission(RBACManager::PERM_VIEW_REPORTS);
+
+        if (($_POST['action'] ?? '') === 'send_report_email') {
+            $this->sendReportByEmail();
+
+            if (defined('PHPUNIT_RUNNING') && PHPUNIT_RUNNING) {
+                return;
+            }
+
+            header('Location: /reports');
+            exit();
+        }
+
         // Redirect to GET request with parameters
         $params = [];
 
@@ -105,5 +119,108 @@ class ReportsController extends Controller
 
         header('Location: ' . $url);
         exit();
+    }
+
+    /**
+     * Send a selected aggregate report via email using the configured template.
+     */
+    private function sendReportByEmail(): void
+    {
+        $reportId = (int) ($_POST['report_id'] ?? 0);
+        $recipientsInput = $_POST['recipients'] ?? '';
+        $recipients = array_values(array_filter(array_map('trim', explode(',', $recipientsInput))));
+
+        if ($reportId <= 0) {
+            MessageHelper::addMessage('Invalid report selected for emailing.', 'error');
+            return;
+        }
+
+        if (empty($recipients)) {
+            MessageHelper::addMessage('Please provide at least one recipient email address.', 'error');
+            return;
+        }
+
+        $report = DmarcReport::getReportDetails($reportId);
+
+        if (!$report) {
+            MessageHelper::addMessage('Unable to load the requested report.', 'error');
+            return;
+        }
+
+        $records = DmarcReport::getAggregateRecords($reportId);
+        $summary = $this->buildReportSummary($records);
+
+        $subject = sprintf(
+            'DMARC Report for %s (%s - %s)',
+            $report['domain'] ?? 'domain',
+            date('Y-m-d', (int) $report['date_range_begin']),
+            date('Y-m-d', (int) $report['date_range_end'])
+        );
+
+        $templateData = [
+            'subject' => $subject,
+            'report' => $report,
+            'summary' => $summary,
+            'records' => array_slice($records, 0, 25),
+        ];
+
+        $success = true;
+        $failedRecipients = [];
+
+        foreach ($recipients as $recipient) {
+            $sent = Mailer::sendTemplate($recipient, $subject, 'report_send', $templateData);
+            if (!$sent) {
+                $success = false;
+                $failedRecipients[] = $recipient;
+            }
+        }
+
+        if ($success) {
+            MessageHelper::addMessage('Report emailed successfully to ' . implode(', ', $recipients) . '.', 'success');
+        } else {
+            MessageHelper::addMessage(
+                'Unable to send the report to: ' . implode(', ', $failedRecipients) . '.',
+                'error'
+            );
+        }
+    }
+
+    /**
+     * Build summary metrics for a DMARC aggregate report.
+     */
+    private function buildReportSummary(array $records): array
+    {
+        $summary = [
+            'total_volume' => 0,
+            'passed_count' => 0,
+            'quarantined_count' => 0,
+            'rejected_count' => 0,
+            'dkim_pass_count' => 0,
+            'spf_pass_count' => 0,
+        ];
+
+        foreach ($records as $record) {
+            $count = (int) ($record['count'] ?? 0);
+            $summary['total_volume'] += $count;
+
+            $disposition = $record['disposition'] ?? '';
+            if ($disposition === 'none') {
+                $summary['passed_count'] += $count;
+            } elseif ($disposition === 'quarantine') {
+                $summary['quarantined_count'] += $count;
+            } elseif ($disposition === 'reject') {
+                $summary['rejected_count'] += $count;
+            }
+
+            if (($record['dkim_result'] ?? '') === 'pass') {
+                $summary['dkim_pass_count'] += $count;
+            }
+
+            if (($record['spf_result'] ?? '') === 'pass') {
+                $summary['spf_pass_count'] += $count;
+            }
+        }
+
+        return $summary;
     }
 }

--- a/root/app/Core/Mailer.php
+++ b/root/app/Core/Mailer.php
@@ -20,6 +20,11 @@ use App\Core\ErrorManager;
 class Mailer
 {
     /**
+     * @var callable|null Custom transport used for testing.
+     */
+    private static $transportOverride = null;
+
+    /**
      * Send an email via configured SMTP server.
      *
      * @param string $to      Recipient address
@@ -29,6 +34,10 @@ class Mailer
      */
     public static function send(string $to, string $subject, string $body, bool $html = false): bool
     {
+        if (self::$transportOverride !== null) {
+            return (bool) call_user_func(self::$transportOverride, $to, $subject, $body, $html);
+        }
+
         $mail = new PHPMailer(true);
         try {
             $mail->isSMTP();
@@ -95,5 +104,13 @@ class Mailer
         $body = ob_get_clean();
 
         return self::send($to, $subject, $body, true);
+    }
+
+    /**
+     * Override the transport handler (used for automated tests).
+     */
+    public static function setTransportOverride(?callable $transport): void
+    {
+        self::$transportOverride = $transport;
     }
 }

--- a/root/app/Core/Router.php
+++ b/root/app/Core/Router.php
@@ -68,6 +68,10 @@ class Router
             // Alerting system
             $r->addRoute('GET', '/alerts', [\App\Controllers\AlertController::class, 'handleRequest']);
             $r->addRoute('POST', '/alerts', [\App\Controllers\AlertController::class, 'handleSubmission']);
+
+            // Email digest scheduling
+            $r->addRoute('GET', '/email-digests', [\App\Controllers\EmailDigestController::class, 'handleRequest']);
+            $r->addRoute('POST', '/email-digests', [\App\Controllers\EmailDigestController::class, 'handleSubmission']);
             
             // Reports management and PDF generation
             $r->addRoute('GET', '/reports-management', [\App\Controllers\ReportsManagementController::class, 'handleRequest']);

--- a/root/app/Services/AlertService.php
+++ b/root/app/Services/AlertService.php
@@ -1,0 +1,56 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+
+namespace App\Services;
+
+use App\Models\Alert;
+use Throwable;
+
+/**
+ * Service helper for executing alert rule checks across the application.
+ */
+class AlertService
+{
+    /**
+     * Evaluate all enabled alert rules and dispatch notifications for new incidents.
+     *
+     * @return array<int, array<string, mixed>> Summary of processed incidents.
+     */
+    public static function runAlertChecks(): array
+    {
+        $results = [];
+
+        try {
+            $triggeredIncidents = Alert::checkAlertRules();
+        } catch (Throwable $exception) {
+            // Surface the exception upstream for logging while preserving compatibility.
+            throw $exception;
+        }
+
+        foreach ($triggeredIncidents as $incident) {
+            $incidentId = $incident['incident_id'] ?? null;
+            if ($incidentId === null) {
+                continue;
+            }
+
+            $notificationsSent = false;
+
+            try {
+                $notificationsSent = Alert::sendNotifications($incidentId);
+            } catch (Throwable $exception) {
+                // Allow notification failures to bubble up for diagnostics while
+                // still returning the incident context to the caller.
+                throw $exception;
+            }
+
+            $results[] = [
+                'incident_id' => $incidentId,
+                'rule' => $incident['rule'] ?? [],
+                'metric_value' => $incident['metric_value'] ?? null,
+                'notifications_sent' => $notificationsSent,
+            ];
+        }
+
+        return $results;
+    }
+}

--- a/root/app/Services/EmailDigestService.php
+++ b/root/app/Services/EmailDigestService.php
@@ -1,0 +1,285 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+
+namespace App\Services;
+
+use App\Core\Mailer;
+use App\Models\EmailDigest;
+use DateInterval;
+use DateTimeImmutable;
+use Throwable;
+
+/**
+ * Coordinates scheduled email digest generation and delivery.
+ */
+class EmailDigestService
+{
+    /**
+     * Process all enabled digest schedules that are due to run.
+     *
+     * @param DateTimeImmutable|null $now Optional time reference for testing.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function processDueDigests(?DateTimeImmutable $now = null): array
+    {
+        $referenceTime = $now ?? new DateTimeImmutable('now');
+        $schedules = EmailDigest::getEnabledSchedules();
+        $results = [];
+
+        foreach ($schedules as $schedule) {
+            $parsedFrequency = self::parseFrequency($schedule['frequency'] ?? '');
+            if ($parsedFrequency === null) {
+                continue;
+            }
+
+            if (!self::isScheduleDue($schedule, $referenceTime, $parsedFrequency)) {
+                continue;
+            }
+
+            [$startDate, $endDate] = self::determinePeriod($schedule, $referenceTime, $parsedFrequency);
+            $digestData = EmailDigest::generateDigestData((int) $schedule['id'], $startDate, $endDate);
+
+            $recipients = json_decode($schedule['recipients'] ?? '[]', true) ?? [];
+            $subject = self::buildSubject($schedule['name'] ?? 'DMARC Digest', $startDate, $endDate);
+            $template = self::resolveTemplate($parsedFrequency['type']);
+            $nextRun = self::computeNextRun($schedule, $referenceTime, $parsedFrequency);
+
+            $success = true;
+            $failedRecipients = [];
+            $errorMessage = '';
+
+            if (empty($digestData)) {
+                $success = false;
+                $errorMessage = 'No data available for the selected reporting period';
+            } elseif (empty($recipients)) {
+                $success = false;
+                $errorMessage = 'No recipients configured for this digest schedule';
+            } else {
+                foreach ($recipients as $recipient) {
+                    $sent = Mailer::sendTemplate(
+                        $recipient,
+                        $subject,
+                        $template,
+                        [
+                            'subject' => $subject,
+                            'digest' => $digestData,
+                            'schedule' => $schedule,
+                            'range_days' => $parsedFrequency['range_days'],
+                        ]
+                    );
+
+                    if (!$sent) {
+                        $success = false;
+                        $failedRecipients[] = $recipient;
+                    }
+                }
+
+                if (!empty($failedRecipients)) {
+                    $errorMessage = 'Failed recipients: ' . implode(', ', $failedRecipients);
+                }
+            }
+
+            EmailDigest::logDigestSend(
+                (int) $schedule['id'],
+                $recipients,
+                $subject,
+                $startDate,
+                $endDate,
+                $success,
+                $errorMessage
+            );
+
+            EmailDigest::updateLastSent(
+                (int) $schedule['id'],
+                $nextRun ? $nextRun->format('Y-m-d H:i:s') : null
+            );
+
+            $results[] = [
+                'schedule_id' => (int) $schedule['id'],
+                'success' => $success,
+                'recipients' => $recipients,
+                'failed_recipients' => $failedRecipients,
+                'start_date' => $startDate,
+                'end_date' => $endDate,
+                'next_run' => $nextRun ? $nextRun->format('Y-m-d H:i:s') : null,
+                'message' => $errorMessage,
+            ];
+        }
+
+        return $results;
+    }
+
+    /**
+     * Break down a stored frequency string.
+     */
+    private static function parseFrequency(string $frequency): ?array
+    {
+        $parts = explode(':', $frequency, 2);
+        $type = $parts[0] ?? '';
+        $customDays = null;
+
+        if ($type === 'custom' && isset($parts[1]) && is_numeric($parts[1])) {
+            $customDays = max(1, (int) $parts[1]);
+        }
+
+        $rangeDays = match ($type) {
+            'daily' => 1,
+            'weekly' => 7,
+            'monthly' => 30,
+            'custom' => $customDays ?? 7,
+            default => null,
+        };
+
+        if ($rangeDays === null) {
+            return null;
+        }
+
+        return [
+            'type' => $type,
+            'custom_days' => $customDays,
+            'range_days' => $rangeDays,
+        ];
+    }
+
+    /**
+     * Determine whether a schedule should run at the current time.
+     */
+    private static function isScheduleDue(array $schedule, DateTimeImmutable $now, array $parsed): bool
+    {
+        if ((int) ($schedule['enabled'] ?? 0) !== 1) {
+            return false;
+        }
+
+        if (!empty($schedule['next_scheduled'])) {
+            try {
+                $next = new DateTimeImmutable($schedule['next_scheduled']);
+                return $next <= $now;
+            } catch (Throwable $exception) {
+                // If parsing fails, treat it as due immediately.
+                return true;
+            }
+        }
+
+        if (!empty($schedule['last_sent'])) {
+            try {
+                $lastSent = new DateTimeImmutable($schedule['last_sent']);
+            } catch (Throwable $exception) {
+                return true;
+            }
+
+            $interval = self::buildInterval($parsed);
+            return $lastSent->add($interval) <= $now;
+        }
+
+        // No prior runs or scheduling information — run immediately.
+        return true;
+    }
+
+    /**
+     * Compute the next scheduled runtime for a digest after the current execution.
+     */
+    private static function computeNextRun(array $schedule, DateTimeImmutable $now, array $parsed): ?DateTimeImmutable
+    {
+        $interval = self::buildInterval($parsed);
+
+        if (!empty($schedule['next_scheduled'])) {
+            try {
+                $existing = new DateTimeImmutable($schedule['next_scheduled']);
+                if ($existing <= $now) {
+                    return $now->add($interval);
+                }
+                return $existing->add($interval);
+            } catch (Throwable $exception) {
+                // Fall through to default scheduling below.
+            }
+        }
+
+        if (!empty($schedule['last_sent'])) {
+            try {
+                $lastSent = new DateTimeImmutable($schedule['last_sent']);
+                return $lastSent->add($interval);
+            } catch (Throwable $exception) {
+                // Default to now-based scheduling
+            }
+        }
+
+        return $now->add($interval);
+    }
+
+    /**
+     * Determine the reporting window for a digest run.
+     */
+    private static function determinePeriod(array $schedule, DateTimeImmutable $now, array $parsed): array
+    {
+        $endDate = $now->format('Y-m-d');
+
+        if (!empty($schedule['last_sent'])) {
+            try {
+                $lastSent = new DateTimeImmutable($schedule['last_sent']);
+                $startReference = $lastSent;
+            } catch (Throwable $exception) {
+                $startReference = self::defaultStartReference($now, $parsed);
+            }
+        } else {
+            $startReference = self::defaultStartReference($now, $parsed);
+        }
+
+        $startDate = $startReference->format('Y-m-d');
+
+        if ($startReference > $now) {
+            $startDate = $now->format('Y-m-d');
+        }
+
+        return [$startDate, $endDate];
+    }
+
+    /**
+     * Resolve the template filename for a digest frequency.
+     */
+    private static function resolveTemplate(string $type): string
+    {
+        return match ($type) {
+            'daily' => 'digest_daily',
+            'weekly' => 'digest_weekly',
+            'monthly' => 'digest_monthly',
+            'custom' => 'digest_custom',
+            default => 'digest_weekly',
+        };
+    }
+
+    /**
+     * Build the next-run subject line.
+     */
+    private static function buildSubject(string $name, string $startDate, string $endDate): string
+    {
+        return sprintf('DMARC Digest: %s (%s - %s)', $name, $startDate, $endDate);
+    }
+
+    /**
+     * Translate parsed frequency metadata into a DateInterval.
+     */
+    private static function buildInterval(array $parsed): DateInterval
+    {
+        return match ($parsed['type']) {
+            'daily' => new DateInterval('P1D'),
+            'weekly' => new DateInterval('P7D'),
+            'monthly' => new DateInterval('P1M'),
+            'custom' => new DateInterval('P' . max(1, (int) ($parsed['custom_days'] ?? $parsed['range_days'])) . 'D'),
+            default => new DateInterval('P1D'),
+        };
+    }
+
+    /**
+     * Fallback start-date reference when none is stored.
+     */
+    private static function defaultStartReference(DateTimeImmutable $now, array $parsed): DateTimeImmutable
+    {
+        if ($parsed['type'] === 'monthly') {
+            return $now->sub(new DateInterval('P1M'));
+        }
+
+        $days = max(0, $parsed['range_days'] - 1);
+        return $now->sub(new DateInterval('P' . $days . 'D'));
+    }
+}

--- a/root/app/Templates/alert_incident.php
+++ b/root/app/Templates/alert_incident.php
@@ -1,0 +1,49 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+?>
+<h2 style="margin-top: 0; font-size: 18px;">Incident Triggered: <?= htmlspecialchars($incident['rule_name'] ?? 'Alert') ?></h2>
+<p style="font-size: 14px; line-height: 1.6;">An alert rule has detected unusual activity that requires your attention.</p>
+
+<table>
+    <tr>
+        <th>Severity</th>
+        <td>
+            <?php $severity = $incident['severity'] ?? 'medium'; ?>
+            <span class="badge <?= $severity === 'critical' || $severity === 'high' ? 'badge-danger' : ($severity === 'medium' ? 'badge-warning' : 'badge-success') ?>">
+                <?= htmlspecialchars(ucfirst($severity)) ?>
+            </span>
+        </td>
+    </tr>
+    <tr>
+        <th>Status</th>
+        <td><?= htmlspecialchars(ucfirst($incident['status'] ?? 'open')) ?></td>
+    </tr>
+    <tr>
+        <th>Triggered</th>
+        <td><?= htmlspecialchars($incident['triggered_at'] ?? '') ?></td>
+    </tr>
+    <tr>
+        <th>Metric Value</th>
+        <td><?= htmlspecialchars((string) ($incident['metric_value'] ?? '')) ?> (threshold <?= htmlspecialchars((string) ($incident['threshold_value'] ?? '')) ?>)</td>
+    </tr>
+</table>
+
+<p style="font-size: 14px; line-height: 1.6; margin-top: 16px;">Summary:</p>
+<p style="background-color: #f5f7fb; padding: 12px 16px; border-radius: 6px; font-size: 14px;">
+    <?= htmlspecialchars($incident['message'] ?? '') ?>
+</p>
+
+<?php if (!empty($details) && is_array($details)): ?>
+    <p style="font-size: 14px; line-height: 1.6; margin-top: 16px;">Context:</p>
+    <table>
+        <?php foreach ($details as $key => $value): ?>
+            <tr>
+                <th><?= htmlspecialchars(ucwords(str_replace('_', ' ', (string) $key))) ?></th>
+                <td><?= htmlspecialchars((string) $value) ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+<?php endif; ?>
+
+<p style="margin-top: 24px; font-size: 14px;">Please log into the DMARC dashboard to acknowledge and investigate this incident.</p>
+<p><a href="<?= getenv('APP_URL') ?: 'https://example.com' ?>/alerts" class="btn">View incidents</a></p>

--- a/root/app/Templates/digest_base.php
+++ b/root/app/Templates/digest_base.php
@@ -1,0 +1,80 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+?>
+<h2 style="margin-top: 0; font-size: 18px;"><?= htmlspecialchars($heading ?? 'DMARC Digest') ?></h2>
+<p style="font-size: 14px; line-height: 1.6;">Reporting period: <?= htmlspecialchars($digest['period']['start'] ?? '') ?> to <?= htmlspecialchars($digest['period']['end'] ?? '') ?>.</p>
+
+<?php $summary = $digest['summary'] ?? []; ?>
+<table>
+    <tr>
+        <th>Domains</th>
+        <td><?= number_format((int) ($summary['domain_count'] ?? 0)) ?></td>
+    </tr>
+    <tr>
+        <th>Reports Received</th>
+        <td><?= number_format((int) ($summary['report_count'] ?? 0)) ?></td>
+    </tr>
+    <tr>
+        <th>Total Volume</th>
+        <td><?= number_format((int) ($summary['total_volume'] ?? 0)) ?></td>
+    </tr>
+    <tr>
+        <th>Delivered</th>
+        <td><span class="badge badge-success"><?= number_format((int) ($summary['passed_count'] ?? 0)) ?></span></td>
+    </tr>
+    <tr>
+        <th>Quarantined</th>
+        <td><span class="badge badge-warning"><?= number_format((int) ($summary['quarantined_count'] ?? 0)) ?></span></td>
+    </tr>
+    <tr>
+        <th>Rejected</th>
+        <td><span class="badge badge-danger"><?= number_format((int) ($summary['rejected_count'] ?? 0)) ?></span></td>
+    </tr>
+</table>
+
+<?php if (!empty($digest['domains'])): ?>
+    <h3 style="margin-top: 24px; font-size: 16px;">Top domains by volume</h3>
+    <table>
+        <thead>
+            <tr>
+                <th>Domain</th>
+                <th>Volume</th>
+                <th>Pass Rate</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach (array_slice($digest['domains'], 0, 10) as $domain): ?>
+            <tr>
+                <td><?= htmlspecialchars($domain['domain'] ?? '') ?></td>
+                <td><?= number_format((int) ($domain['total_volume'] ?? 0)) ?></td>
+                <td><?= isset($domain['pass_rate']) ? htmlspecialchars((string) $domain['pass_rate']) . '%' : 'n/a' ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+<?php endif; ?>
+
+<?php if (!empty($digest['threats'])): ?>
+    <h3 style="margin-top: 24px; font-size: 16px;">Top threat sources</h3>
+    <table>
+        <thead>
+            <tr>
+                <th>Source IP</th>
+                <th>Threat Volume</th>
+                <th>Affected Domains</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($digest['threats'] as $threat): ?>
+            <tr>
+                <td><?= htmlspecialchars($threat['source_ip'] ?? '') ?></td>
+                <td><?= number_format((int) ($threat['threat_volume'] ?? 0)) ?></td>
+                <td><?= number_format((int) ($threat['affected_domains'] ?? 0)) ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+<?php endif; ?>
+
+<p style="margin-top: 24px; font-size: 14px;">Access the dashboard for full drill-down and remediation guidance.</p>
+<p><a href="<?= getenv('APP_URL') ?: 'https://example.com' ?>/analytics" class="btn">View analytics</a></p>

--- a/root/app/Templates/digest_custom.php
+++ b/root/app/Templates/digest_custom.php
@@ -1,0 +1,5 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+?>
+<?php $heading = 'Custom DMARC Digest'; ?>
+<?php require __DIR__ . '/digest_base.php'; ?>

--- a/root/app/Templates/digest_daily.php
+++ b/root/app/Templates/digest_daily.php
@@ -1,0 +1,5 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+?>
+<?php $heading = 'Daily DMARC Summary'; ?>
+<?php require __DIR__ . '/digest_base.php'; ?>

--- a/root/app/Templates/digest_monthly.php
+++ b/root/app/Templates/digest_monthly.php
@@ -1,0 +1,5 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+?>
+<?php $heading = 'Monthly DMARC Digest'; ?>
+<?php require __DIR__ . '/digest_base.php'; ?>

--- a/root/app/Templates/digest_weekly.php
+++ b/root/app/Templates/digest_weekly.php
@@ -1,0 +1,5 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+?>
+<?php $heading = 'Weekly DMARC Digest'; ?>
+<?php require __DIR__ . '/digest_base.php'; ?>

--- a/root/app/Templates/email_footer.php
+++ b/root/app/Templates/email_footer.php
@@ -1,0 +1,11 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+?>
+    </div>
+    <div class="email-footer">
+        <p style="margin: 0;">You are receiving this message because your account is subscribed to DMARC dashboard notifications.</p>
+        <p style="margin: 8px 0 0;">&copy; <?= date('Y') ?> DMARC Dashboard</p>
+    </div>
+</div>
+</body>
+</html>

--- a/root/app/Templates/email_header.php
+++ b/root/app/Templates/email_header.php
@@ -1,0 +1,83 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title><?= htmlspecialchars($subject ?? 'DMARC Notification') ?></title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background-color: #f5f7fb;
+            color: #2e3a59;
+            margin: 0;
+            padding: 0;
+        }
+        .email-container {
+            max-width: 640px;
+            margin: 0 auto;
+            background-color: #ffffff;
+            border-radius: 8px;
+            box-shadow: 0 4px 12px rgba(46, 58, 89, 0.08);
+            overflow: hidden;
+        }
+        .email-header {
+            background: linear-gradient(135deg, #4a67ff, #5ac8fa);
+            color: #ffffff;
+            padding: 24px;
+        }
+        .email-content {
+            padding: 24px;
+        }
+        .email-footer {
+            padding: 16px 24px 32px;
+            text-align: center;
+            color: #7a869a;
+            font-size: 12px;
+        }
+        .btn {
+            display: inline-block;
+            background-color: #4a67ff;
+            color: #ffffff;
+            text-decoration: none;
+            padding: 10px 18px;
+            border-radius: 4px;
+            font-weight: 600;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 16px;
+        }
+        th, td {
+            padding: 8px;
+            border-bottom: 1px solid #eef1f6;
+            text-align: left;
+        }
+        th {
+            background-color: #f5f7fb;
+            font-size: 13px;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: #7a869a;
+        }
+        .badge {
+            display: inline-block;
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 12px;
+            font-weight: 600;
+        }
+        .badge-success { background-color: #e3fcef; color: #1f845a; }
+        .badge-warning { background-color: #fff7d6; color: #8a6116; }
+        .badge-danger { background-color: #ffe8e7; color: #c9372c; }
+    </style>
+</head>
+<body>
+<div class="email-container">
+    <div class="email-header">
+        <h1 style="margin: 0; font-size: 20px;">DMARC Dashboard</h1>
+        <p style="margin: 4px 0 0; font-size: 14px; opacity: 0.85;">Automated notification</p>
+    </div>
+    <div class="email-content">

--- a/root/app/Templates/report_send.php
+++ b/root/app/Templates/report_send.php
@@ -1,0 +1,58 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+?>
+<h2 style="margin-top: 0; font-size: 18px;">DMARC Aggregate Report</h2>
+<p style="font-size: 14px; line-height: 1.6;">Domain <?= htmlspecialchars($report['domain'] ?? '') ?> &middot; Report ID <?= htmlspecialchars($report['report_id'] ?? '') ?></p>
+<p style="font-size: 14px; line-height: 1.6;">Reporting window: <?= date('Y-m-d H:i', (int) ($report['date_range_begin'] ?? time())) ?> to <?= date('Y-m-d H:i', (int) ($report['date_range_end'] ?? time())) ?>.</p>
+
+<table>
+    <tr>
+        <th>Organization</th>
+        <td><?= htmlspecialchars($report['org_name'] ?? '') ?></td>
+    </tr>
+    <tr>
+        <th>Total Volume</th>
+        <td><?= number_format((int) ($summary['total_volume'] ?? 0)) ?></td>
+    </tr>
+    <tr>
+        <th>Delivered</th>
+        <td><span class="badge badge-success"><?= number_format((int) ($summary['passed_count'] ?? 0)) ?></span></td>
+    </tr>
+    <tr>
+        <th>Quarantined</th>
+        <td><span class="badge badge-warning"><?= number_format((int) ($summary['quarantined_count'] ?? 0)) ?></span></td>
+    </tr>
+    <tr>
+        <th>Rejected</th>
+        <td><span class="badge badge-danger"><?= number_format((int) ($summary['rejected_count'] ?? 0)) ?></span></td>
+    </tr>
+</table>
+
+<?php if (!empty($records)): ?>
+    <h3 style="margin-top: 24px; font-size: 16px;">Top sending sources</h3>
+    <table>
+        <thead>
+            <tr>
+                <th>Source IP</th>
+                <th>Messages</th>
+                <th>Disposition</th>
+                <th>DKIM</th>
+                <th>SPF</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($records as $record): ?>
+                <tr>
+                    <td><?= htmlspecialchars($record['source_ip'] ?? '') ?></td>
+                    <td><?= number_format((int) ($record['count'] ?? 0)) ?></td>
+                    <td><?= htmlspecialchars($record['disposition'] ?? '') ?></td>
+                    <td><?= htmlspecialchars($record['dkim_result'] ?? '') ?></td>
+                    <td><?= htmlspecialchars($record['spf_result'] ?? '') ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+<?php endif; ?>
+
+<p style="margin-top: 24px; font-size: 14px;">Log into the dashboard to review the full report and related forensic details.</p>
+<p><a href="<?= getenv('APP_URL') ?: 'https://example.com' ?>/reports" class="btn">View in dashboard</a></p>

--- a/root/app/Views/alert_incidents.php
+++ b/root/app/Views/alert_incidents.php
@@ -1,0 +1,120 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+/**
+ * Alert incident management view.
+ */
+
+require 'partials/header.php';
+
+function incidentSeverity(string $severity): string
+{
+    return match ($severity) {
+        'critical' => 'label-error',
+        'high' => 'label-warning',
+        'medium' => 'label-primary',
+        'low' => 'label-secondary',
+        default => 'label-secondary',
+    };
+}
+
+function incidentStatus(string $status): string
+{
+    return match ($status) {
+        'open' => 'label-error',
+        'acknowledged' => 'label-warning',
+        'resolved' => 'label-success',
+        default => 'label-secondary',
+    };
+}
+
+?>
+
+<style>
+.incident-card {
+    border: 1px solid #e9ecef;
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    background: #ffffff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+.incident-actions {
+    margin-top: 0.75rem;
+}
+</style>
+
+<div class="columns">
+    <div class="column col-12">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h2>
+                <i class="icon icon-flag icon-2x text-error mr-2"></i>
+                Active Incidents
+            </h2>
+            <a href="/alerts" class="btn btn-link btn-sm"><i class="icon icon-arrow-left"></i> Back to alerts dashboard</a>
+        </div>
+        <p class="text-gray">Review triggered incidents, investigate anomalies, and acknowledge items once handled.</p>
+    </div>
+</div>
+
+<?php if (empty($this->data['incidents'])): ?>
+    <div class="columns">
+        <div class="column col-12">
+            <div class="empty">
+                <div class="empty-icon"><i class="icon icon-4x icon-check text-success"></i></div>
+                <p class="empty-title h5">All clear</p>
+                <p class="empty-subtitle">There are no open incidents at this time.</p>
+            </div>
+        </div>
+    </div>
+<?php else: ?>
+    <?php foreach ($this->data['incidents'] as $incident): ?>
+        <?php $channels = json_decode($incident['notification_channels'] ?? '[]', true) ?? []; ?>
+        <div class="columns">
+            <div class="column col-12">
+                <div class="incident-card">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div>
+                            <h4 class="mb-1"><?= htmlspecialchars($incident['rule_name'] ?? 'Alert') ?></h4>
+                            <p class="mb-1"><?= htmlspecialchars($incident['message']) ?></p>
+                            <small class="text-gray">Triggered at <?= htmlspecialchars($incident['triggered_at']) ?> &middot; Metric value <?= htmlspecialchars((string) $incident['metric_value']) ?> (threshold <?= htmlspecialchars((string) $incident['threshold_value']) ?>)</small>
+                            <?php if (!empty($incident['details'])): ?>
+                                <?php $details = json_decode($incident['details'], true) ?? []; ?>
+                                <?php if (!empty($details)): ?>
+                                    <div class="mt-1">
+                                        <small class="text-gray">Context:</small>
+                                        <ul>
+                                            <?php foreach ($details as $key => $value): ?>
+                                                <li><small><?= htmlspecialchars(ucwords(str_replace('_', ' ', (string) $key))) ?>: <?= htmlspecialchars((string) $value) ?></small></li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    </div>
+                                <?php endif; ?>
+                            <?php endif; ?>
+                            <div class="mt-1">
+                                <small class="text-gray">Channels: <?= empty($channels) ? 'None configured' : htmlspecialchars(implode(', ', $channels)) ?></small>
+                            </div>
+                        </div>
+                        <div class="text-right">
+                            <span class="label <?= incidentSeverity($incident['severity'] ?? 'medium') ?> mb-1"><?= ucfirst($incident['severity'] ?? 'medium') ?></span>
+                            <br>
+                            <span class="label <?= incidentStatus($incident['status'] ?? 'open') ?>"><?= ucfirst($incident['status'] ?? 'open') ?></span>
+                        </div>
+                    </div>
+
+                    <div class="incident-actions">
+                        <form method="POST" action="/alerts" class="d-inline">
+                            <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?? '' ?>">
+                            <input type="hidden" name="action" value="acknowledge_incident">
+                            <input type="hidden" name="incident_id" value="<?= (int) $incident['id'] ?>">
+                            <button type="submit" class="btn btn-primary btn-sm" <?= ($incident['status'] ?? '') !== 'open' ? 'disabled' : '' ?>>
+                                <i class="icon icon-check"></i> Acknowledge
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    <?php endforeach; ?>
+<?php endif; ?>
+
+<?php require 'partials/footer.php'; ?>

--- a/root/app/Views/alert_rules.php
+++ b/root/app/Views/alert_rules.php
@@ -1,0 +1,138 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+/**
+ * Alert rules management view.
+ */
+
+require 'partials/header.php';
+
+function alertSeverityBadge(string $severity): string
+{
+    return match ($severity) {
+        'critical' => 'label-error',
+        'high' => 'label-warning',
+        'medium' => 'label-primary',
+        'low' => 'label-secondary',
+        default => 'label-secondary',
+    };
+}
+
+?>
+
+<style>
+.rules-card {
+    border: 1px solid #e9ecef;
+    border-radius: 8px;
+    padding: 1.5rem;
+    background: #ffffff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+.rules-table td {
+    vertical-align: top;
+}
+</style>
+
+<div class="columns">
+    <div class="column col-12">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h2>
+                <i class="icon icon-bookmark icon-2x text-primary mr-2"></i>
+                Alert Rules
+            </h2>
+            <div>
+                <form method="POST" action="/alerts" class="d-inline mr-1">
+                    <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?? '' ?>">
+                    <input type="hidden" name="action" value="test_alerts">
+                    <button type="submit" class="btn btn-success btn-sm">
+                        <i class="icon icon-refresh"></i> Test Alerts
+                    </button>
+                </form>
+                <a href="/alerts?action=create-rule" class="btn btn-primary btn-sm">
+                    <i class="icon icon-plus"></i> Create Rule
+                </a>
+            </div>
+        </div>
+        <p class="text-gray">Define automated monitoring rules to detect anomalies and trigger incident notifications.</p>
+    </div>
+</div>
+
+<div class="columns">
+    <div class="column col-12">
+        <div class="rules-card">
+            <?php if (empty($this->data['rules'])): ?>
+                <div class="empty">
+                    <div class="empty-icon"><i class="icon icon-4x icon-flag text-gray"></i></div>
+                    <p class="empty-title h5">No alert rules configured</p>
+                    <p class="empty-subtitle">Create your first rule to begin monitoring DMARC health.</p>
+                    <div class="empty-action">
+                        <a class="btn btn-primary" href="/alerts?action=create-rule">Create Rule</a>
+                    </div>
+                </div>
+            <?php else: ?>
+                <div class="table-responsive">
+                    <table class="table rules-table">
+                        <thead>
+                            <tr>
+                                <th>Name &amp; Description</th>
+                                <th>Metric &amp; Threshold</th>
+                                <th>Scope</th>
+                                <th>Notifications</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($this->data['rules'] as $rule): ?>
+                                <?php $channels = json_decode($rule['notification_channels'] ?? '[]', true) ?? []; ?>
+                                <?php $recipients = json_decode($rule['notification_recipients'] ?? '[]', true) ?? []; ?>
+                                <tr>
+                                    <td>
+                                        <strong><?= htmlspecialchars($rule['name']) ?></strong>
+                                        <br>
+                                        <small class="text-gray"><?= htmlspecialchars($rule['description'] ?? '') ?: 'No description' ?></small>
+                                        <?php if (!empty($rule['incident_count'])): ?>
+                                            <br>
+                                            <small class="text-gray">Open incidents: <?= (int) $rule['incident_count'] ?></small>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td>
+                                        <small>
+                                            Metric: <strong><?= htmlspecialchars(str_replace('_', ' ', $rule['metric'])) ?></strong><br>
+                                            Threshold: <?= htmlspecialchars($rule['threshold_operator']) ?> <?= htmlspecialchars((string) $rule['threshold_value']) ?><br>
+                                            Window: last <?= (int) $rule['time_window'] ?> minutes
+                                        </small>
+                                    </td>
+                                    <td>
+                                        <small>
+                                            Domain: <?= $rule['domain_filter'] !== '' ? htmlspecialchars($rule['domain_filter']) : 'All' ?><br>
+                                            Group: <?= !empty($rule['group_name']) ? htmlspecialchars($rule['group_name']) : 'All' ?>
+                                        </small>
+                                    </td>
+                                    <td>
+                                        <small>
+                                            Channels: <?= empty($channels) ? 'None' : htmlspecialchars(implode(', ', $channels)) ?><br>
+                                            Recipients: <?= empty($recipients) ? 'None' : htmlspecialchars(implode(', ', $recipients)) ?><br>
+                                            <?php if (!empty($rule['webhook_url'])): ?>
+                                                Webhook: <?= htmlspecialchars($rule['webhook_url']) ?>
+                                            <?php endif; ?>
+                                        </small>
+                                    </td>
+                                    <td>
+                                        <span class="label <?= alertSeverityBadge($rule['severity']) ?>"><?= ucfirst($rule['severity']) ?></span>
+                                        <br>
+                                        <span class="label <?= (int) $rule['enabled'] === 1 ? 'label-success' : 'label-secondary' ?> mt-1">
+                                            <?= (int) $rule['enabled'] === 1 ? 'Enabled' : 'Disabled' ?>
+                                        </span>
+                                        <br>
+                                        <small class="text-gray">Last incident: <?= $rule['last_incident'] ? htmlspecialchars($rule['last_incident']) : 'None' ?></small>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>
+
+<?php require 'partials/footer.php'; ?>

--- a/root/app/Views/create_alert_rule.php
+++ b/root/app/Views/create_alert_rule.php
@@ -1,0 +1,177 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+/**
+ * Alert rule creation view.
+ */
+
+require 'partials/header.php';
+
+?>
+
+<style>
+.rule-form-card {
+    border: 1px solid #e9ecef;
+    border-radius: 8px;
+    padding: 1.5rem;
+    background: #ffffff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+.rule-form-card .form-group {
+    margin-bottom: 1rem;
+}
+</style>
+
+<div class="columns">
+    <div class="column col-12">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h2>
+                <i class="icon icon-plus icon-2x text-primary mr-2"></i>
+                Create Alert Rule
+            </h2>
+            <a href="/alerts?action=rules" class="btn btn-link btn-sm"><i class="icon icon-arrow-left"></i> Back to rules</a>
+        </div>
+        <p class="text-gray">Define the conditions that should trigger an incident and how notifications are delivered.</p>
+    </div>
+</div>
+
+<div class="columns">
+    <div class="column col-12 col-lg-8">
+        <div class="rule-form-card">
+            <form method="POST" action="/alerts">
+                <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?? '' ?>">
+                <input type="hidden" name="action" value="create_rule">
+
+                <div class="form-group">
+                    <label class="form-label" for="rule_name">Rule Name</label>
+                    <input type="text" class="form-input" id="rule_name" name="name" required>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="rule_description">Description</label>
+                    <textarea class="form-input" id="rule_description" name="description" rows="2" placeholder="Explain the purpose of this alert"></textarea>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="metric">Metric</label>
+                    <select class="form-select" id="metric" name="metric" required>
+                        <option value="dmarc_failure_rate">DMARC failure rate (%)</option>
+                        <option value="volume_increase">Volume increase (%)</option>
+                        <option value="new_failure_ips">New failing IPs</option>
+                        <option value="spf_failures">SPF failures</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="threshold_operator">Threshold</label>
+                    <div class="input-group">
+                        <select class="form-select" id="threshold_operator" name="threshold_operator">
+                            <option value=">">&gt;</option>
+                            <option value=">=">&gt;=</option>
+                            <option value="<">&lt;</option>
+                            <option value="<=">&lt;=</option>
+                            <option value="==">Equals</option>
+                        </select>
+                        <input type="number" step="0.01" class="form-input" name="threshold_value" value="10" required>
+                    </div>
+                    <small class="form-input-hint">Compare the selected metric against this value.</small>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="time_window">Time Window (minutes)</label>
+                    <input type="number" min="5" step="5" class="form-input" id="time_window" name="time_window" value="60" required>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="domain_filter">Domain Filter</label>
+                    <input type="text" class="form-input" id="domain_filter" name="domain_filter" placeholder="example.com (optional)">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="group_filter">Domain Group</label>
+                    <select class="form-select" id="group_filter" name="group_filter">
+                        <option value="">All groups</option>
+                        <?php foreach ($this->data['groups'] as $group): ?>
+                            <option value="<?= (int) $group['id'] ?>"><?= htmlspecialchars($group['name']) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="severity">Severity</label>
+                    <select class="form-select" id="severity" name="severity">
+                        <option value="low">Low</option>
+                        <option value="medium" selected>Medium</option>
+                        <option value="high">High</option>
+                        <option value="critical">Critical</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label">Notification Channels</label>
+                    <label class="form-checkbox">
+                        <input type="checkbox" name="notification_channels[]" value="email" checked>
+                        <i class="form-icon"></i> Email
+                    </label>
+                    <label class="form-checkbox">
+                        <input type="checkbox" name="notification_channels[]" value="webhook" id="channel_webhook">
+                        <i class="form-icon"></i> Webhook
+                    </label>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="notification_recipients">Notification Recipients</label>
+                    <input type="text" class="form-input" id="notification_recipients" name="notification_recipients" placeholder="Comma-separated email addresses">
+                </div>
+
+                <div class="form-group" id="webhook-url-group" style="display: none;">
+                    <label class="form-label" for="webhook_url">Webhook URL</label>
+                    <input type="url" class="form-input" id="webhook_url" name="webhook_url" placeholder="https://example.com/webhook">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-checkbox">
+                        <input type="checkbox" name="enabled" checked>
+                        <i class="form-icon"></i> Enable this rule immediately
+                    </label>
+                </div>
+
+                <button type="submit" class="btn btn-primary">
+                    <i class="icon icon-check"></i> Save Rule
+                </button>
+            </form>
+        </div>
+    </div>
+
+    <div class="column col-12 col-lg-4">
+        <div class="rule-form-card">
+            <h4 class="mb-2"><i class="icon icon-info"></i> Tips</h4>
+            <ul>
+                <li><small>Combine domain or group filters to focus alerts on specific business units.</small></li>
+                <li><small>Use higher thresholds for informational alerts and lower thresholds for critical incidents.</small></li>
+                <li><small>Multiple recipients can be provided using commas.</small></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<script>
+(function () {
+    const webhookCheckbox = document.getElementById('channel_webhook');
+    const webhookGroup = document.getElementById('webhook-url-group');
+
+    function toggleWebhookField() {
+        if (!webhookCheckbox || !webhookGroup) {
+            return;
+        }
+
+        webhookGroup.style.display = webhookCheckbox.checked ? 'block' : 'none';
+    }
+
+    if (webhookCheckbox) {
+        webhookCheckbox.addEventListener('change', toggleWebhookField);
+        toggleWebhookField();
+    }
+})();
+</script>
+
+<?php require 'partials/footer.php'; ?>

--- a/root/app/Views/email_digests.php
+++ b/root/app/Views/email_digests.php
@@ -1,0 +1,243 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+/**
+ * Email digest scheduling view.
+ */
+
+require 'partials/header.php';
+
+function formatFrequency(string $frequency): string
+{
+    if (str_starts_with($frequency, 'custom:')) {
+        $parts = explode(':', $frequency, 2);
+        $days = isset($parts[1]) && is_numeric($parts[1]) ? (int) $parts[1] : 7;
+        return 'Custom (' . $days . ' day' . ($days === 1 ? '' : 's') . ')';
+    }
+
+    return match ($frequency) {
+        'daily' => 'Daily',
+        'weekly' => 'Weekly',
+        'monthly' => 'Monthly',
+        default => ucfirst($frequency),
+    };
+}
+
+?>
+
+<style>
+.digest-card {
+    border: 1px solid #e9ecef;
+    border-radius: 8px;
+    padding: 1.5rem;
+    background: #ffffff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+.digest-form .form-group {
+    margin-bottom: 1rem;
+}
+.digest-table td {
+    vertical-align: top;
+}
+.badge-enabled {
+    background-color: #32b643;
+    color: #fff;
+}
+.badge-disabled {
+    background-color: #e85600;
+    color: #fff;
+}
+</style>
+
+<div class="columns">
+    <div class="column col-12">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h2>
+                <i class="icon icon-mail icon-2x text-primary mr-2"></i>
+                Email Digest Scheduling
+            </h2>
+            <span class="text-gray">Configure automated weekly, monthly, or custom summary emails.</span>
+        </div>
+    </div>
+</div>
+
+<div class="columns">
+    <div class="column col-12 col-lg-7">
+        <div class="digest-card mb-4">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <h4 class="mb-0">
+                    <i class="icon icon-timer"></i> Scheduled Digests
+                </h4>
+                <span class="label label-rounded label-secondary">
+                    <?= count($this->data['schedules']) ?> Active Schedule<?= count($this->data['schedules']) === 1 ? '' : 's' ?>
+                </span>
+            </div>
+
+            <?php if (empty($this->data['schedules'])): ?>
+                <div class="empty">
+                    <div class="empty-icon"><i class="icon icon-4x icon-calendar text-gray"></i></div>
+                    <p class="empty-title h5">No digests yet</p>
+                    <p class="empty-subtitle">Create a schedule to start delivering recurring insights to your stakeholders.</p>
+                </div>
+            <?php else: ?>
+                <div class="table-responsive">
+                    <table class="table digest-table">
+                        <thead>
+                            <tr>
+                                <th>Name &amp; Recipients</th>
+                                <th>Frequency</th>
+                                <th>Filters</th>
+                                <th>Status</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($this->data['schedules'] as $schedule): ?>
+                                <?php $recipientList = json_decode($schedule['recipients'] ?? '[]', true) ?? []; ?>
+                                <tr>
+                                    <td>
+                                        <strong><?= htmlspecialchars($schedule['name']) ?></strong>
+                                        <br>
+                                        <small class="text-gray">Recipients: <?= htmlspecialchars(implode(', ', $recipientList)) ?: 'None' ?></small>
+                                        <?php if (!empty($schedule['sent_count'])): ?>
+                                            <br><small class="text-gray">Total sends: <?= (int) $schedule['sent_count'] ?></small>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td>
+                                        <span class="chip">
+                                            <?= htmlspecialchars(formatFrequency($schedule['frequency'])) ?>
+                                        </span>
+                                        <br>
+                                        <small class="text-gray">Next run:
+                                            <?= $schedule['next_scheduled'] ? htmlspecialchars($schedule['next_scheduled']) : 'Pending' ?></small>
+                                        <br>
+                                        <small class="text-gray">Last sent:
+                                            <?= $schedule['last_sent'] ? htmlspecialchars($schedule['last_sent']) : 'Never' ?></small>
+                                    </td>
+                                    <td>
+                                        <small>
+                                            Domain: <?= $schedule['domain_filter'] !== '' ? htmlspecialchars($schedule['domain_filter']) : 'All' ?><br>
+                                            Group: <?= !empty($schedule['group_name']) ? htmlspecialchars($schedule['group_name']) : 'All' ?>
+                                        </small>
+                                    </td>
+                                    <td>
+                                        <?php if ((int) $schedule['enabled'] === 1): ?>
+                                            <span class="label badge-enabled">Enabled</span>
+                                        <?php else: ?>
+                                            <span class="label badge-disabled">Disabled</span>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td>
+                                        <form method="POST" action="/email-digests" class="mb-1">
+                                            <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?? '' ?>">
+                                            <input type="hidden" name="action" value="toggle_schedule">
+                                            <input type="hidden" name="schedule_id" value="<?= (int) $schedule['id'] ?>">
+                                            <input type="hidden" name="desired_state" value="<?= (int) $schedule['enabled'] === 1 ? '0' : '1' ?>">
+                                            <button type="submit" class="btn btn-sm <?= (int) $schedule['enabled'] === 1 ? 'btn-warning' : 'btn-success' ?>">
+                                                <?= (int) $schedule['enabled'] === 1 ? 'Disable' : 'Enable' ?>
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <div class="column col-12 col-lg-5">
+        <div class="digest-card digest-form">
+            <h4 class="mb-2">
+                <i class="icon icon-plus"></i> Create Digest Schedule
+            </h4>
+            <form method="POST" action="/email-digests">
+                <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?? '' ?>">
+                <input type="hidden" name="action" value="create_schedule">
+
+                <div class="form-group">
+                    <label class="form-label" for="digest_name">Schedule Name</label>
+                    <input type="text" class="form-input" id="digest_name" name="name" required>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="frequency">Frequency</label>
+                    <select class="form-select" id="frequency" name="frequency">
+                        <option value="daily">Daily Summary</option>
+                        <option value="weekly" selected>Weekly Digest</option>
+                        <option value="monthly">Monthly Digest</option>
+                        <option value="custom">Custom Range</option>
+                    </select>
+                </div>
+
+                <div class="form-group" id="custom-range-group" style="display: none;">
+                    <label class="form-label" for="custom_range_days">Custom Range (days)</label>
+                    <input type="number" min="1" max="90" value="7" class="form-input" id="custom_range_days" name="custom_range_days">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="recipients">Recipients</label>
+                    <input type="text" class="form-input" id="recipients" name="recipients" placeholder="Comma-separated email addresses" required>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="domain_filter">Domain Filter</label>
+                    <input type="text" class="form-input" id="domain_filter" name="domain_filter" placeholder="example.com (optional)">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="group_filter">Domain Group</label>
+                    <select class="form-select" id="group_filter" name="group_filter">
+                        <option value="">All Groups</option>
+                        <?php foreach ($this->data['groups'] as $group): ?>
+                            <option value="<?= (int) $group['id'] ?>"><?= htmlspecialchars($group['name']) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="first_send_at">First Send Time</label>
+                    <input type="datetime-local" class="form-input" id="first_send_at" name="first_send_at">
+                    <small class="form-input-hint">Leave blank to schedule automatically.</small>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-checkbox">
+                        <input type="checkbox" name="start_immediately">
+                        <i class="form-icon"></i> Send on next cron run
+                    </label>
+                    <label class="form-checkbox">
+                        <input type="checkbox" name="enabled" checked>
+                        <i class="form-icon"></i> Enable schedule upon creation
+                    </label>
+                </div>
+
+                <button type="submit" class="btn btn-primary btn-block">
+                    <i class="icon icon-send"></i> Save Schedule
+                </button>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script>
+(function () {
+    const frequencySelect = document.getElementById('frequency');
+    const customGroup = document.getElementById('custom-range-group');
+
+    function toggleCustomRange() {
+        if (!frequencySelect || !customGroup) {
+            return;
+        }
+
+        customGroup.style.display = frequencySelect.value === 'custom' ? 'block' : 'none';
+    }
+
+    if (frequencySelect) {
+        frequencySelect.addEventListener('change', toggleCustomRange);
+        toggleCustomRange();
+    }
+})();
+</script>
+
+<?php require 'partials/footer.php'; ?>

--- a/root/app/Views/partials/header.php
+++ b/root/app/Views/partials/header.php
@@ -84,6 +84,9 @@ $brandingVars = $branding->getBrandingVars();
                 <a class="nav-item" href="/alerts">
                     <i class="icon icon-flag"></i> Alerts
                 </a>
+                <a class="nav-item" href="/email-digests">
+                    <i class="icon icon-mail"></i> Digests
+                </a>
                 <?php endif; ?>
                 
                 <?php if ($rbac->hasPermission(RBACManager::PERM_VIEW_REPORTS)): ?>

--- a/root/app/Views/reports.php
+++ b/root/app/Views/reports.php
@@ -82,6 +82,16 @@ function getAuthResultBadge($result, $total) {
 .sort-header:hover {
     background-color: #f1f3f4;
 }
+.send-report-form {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.3rem;
+    margin-top: 0.5rem;
+}
+.send-report-form .form-input {
+    max-width: 220px;
+}
 </style>
 
 <div class="columns">
@@ -298,6 +308,16 @@ function getAuthResultBadge($result, $total) {
                                             <a href="/report/<?= $report['id'] ?>" class="btn btn-sm btn-primary" title="View Details">
                                                 <i class="icon icon-eye"></i>
                                             </a>
+                                            <form method="POST" action="/reports" class="send-report-form">
+                                                <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?? '' ?>">
+                                                <input type="hidden" name="action" value="send_report_email">
+                                                <input type="hidden" name="report_id" value="<?= (int) $report['id'] ?>">
+                                                <input type="text" name="recipients" class="form-input" placeholder="Emails" required>
+                                                <button type="submit" class="btn btn-sm btn-secondary">
+                                                    <i class="icon icon-send"></i> Send by Email
+                                                </button>
+                                            </form>
+                                            <small class="text-gray">Separate multiple addresses with commas.</small>
                                         </td>
                                     </tr>
                                 <?php endforeach; ?>

--- a/unit/AlertAndDigestFlowTest.php
+++ b/unit/AlertAndDigestFlowTest.php
@@ -1,0 +1,233 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+
+declare(strict_types=1);
+
+define('PHPUNIT_RUNNING', true);
+
+require __DIR__ . '/../root/vendor/autoload.php';
+require __DIR__ . '/../root/config.php';
+require __DIR__ . '/TestHelpers.php';
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+use App\Controllers\AlertController;
+use App\Controllers\ReportsController;
+use App\Core\DatabaseManager;
+use App\Core\RBACManager;
+use App\Core\Mailer;
+use App\Helpers\MessageHelper;
+use App\Models\Alert;
+use App\Models\EmailDigest;
+use App\Services\AlertService;
+use App\Services\EmailDigestService;
+use function TestHelpers\assertContains;
+use function TestHelpers\assertPredicate;
+use function TestHelpers\assertTrue;
+
+$failures = 0;
+
+function resetSessionState(): void
+{
+    $_SESSION['logged_in'] = true;
+    $_SESSION['user_role'] = RBACManager::ROLE_APP_ADMIN;
+    $_SESSION['username'] = 'test-user';
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(8));
+    $_SESSION['messages'] = [];
+}
+
+function insertDomain(string $domainName): int
+{
+    $db = DatabaseManager::getInstance();
+    $db->query('INSERT INTO domains (domain) VALUES (:domain)');
+    $db->bind(':domain', $domainName);
+    $db->execute();
+
+    $db->query('SELECT last_insert_rowid() as id');
+    $result = $db->single();
+    return (int) ($result['id'] ?? 0);
+}
+
+function insertGroup(string $name): int
+{
+    $db = DatabaseManager::getInstance();
+    $db->query('INSERT INTO domain_groups (name, description) VALUES (:name, :description)');
+    $db->bind(':name', $name);
+    $db->bind(':description', 'Automated test group');
+    $db->execute();
+
+    $db->query('SELECT last_insert_rowid() as id');
+    $result = $db->single();
+    return (int) ($result['id'] ?? 0);
+}
+
+function insertDmarcReport(int $domainId, string $identifier): int
+{
+    $now = time();
+    $db = DatabaseManager::getInstance();
+    $db->query('INSERT INTO dmarc_aggregate_reports (domain_id, org_name, email, report_id, date_range_begin, date_range_end, received_at) VALUES (:domain_id, :org_name, :email, :report_id, :start, :end, :received)');
+    $db->bind(':domain_id', $domainId);
+    $db->bind(':org_name', 'Test Org');
+    $db->bind(':email', 'reports@example.com');
+    $db->bind(':report_id', $identifier);
+    $db->bind(':start', $now - 3600);
+    $db->bind(':end', $now);
+    $db->bind(':received', date('Y-m-d H:i:s', $now));
+    $db->execute();
+
+    $db->query('SELECT last_insert_rowid() as id');
+    $result = $db->single();
+    return (int) ($result['id'] ?? 0);
+}
+
+function insertDmarcRecord(int $reportId, string $sourceIp, int $count, string $disposition, string $spf = 'pass', string $dkim = 'pass'): void
+{
+    $db = DatabaseManager::getInstance();
+    $db->query('INSERT INTO dmarc_aggregate_records (report_id, source_ip, count, disposition, dkim_result, spf_result, header_from, envelope_from, envelope_to) VALUES (:report_id, :source_ip, :count, :disposition, :dkim, :spf, :header_from, :envelope_from, :envelope_to)');
+    $db->bind(':report_id', $reportId);
+    $db->bind(':source_ip', $sourceIp);
+    $db->bind(':count', $count);
+    $db->bind(':disposition', $disposition);
+    $db->bind(':dkim', $dkim);
+    $db->bind(':spf', $spf);
+    $db->bind(':header_from', 'example.com');
+    $db->bind(':envelope_from', 'noreply@example.com');
+    $db->bind(':envelope_to', 'postmaster@example.com');
+    $db->execute();
+}
+
+function captureOutput(callable $callback): string
+{
+    ob_start();
+    $callback();
+    return (string) ob_get_clean();
+}
+
+resetSessionState();
+
+// Prepare supporting domain/group data.
+$timestamp = time();
+$domainName = 'alerts-' . $timestamp . '.example';
+$domainId = insertDomain($domainName);
+$groupId = insertGroup('Alert Group ' . $timestamp);
+
+$db = DatabaseManager::getInstance();
+$db->query('INSERT INTO domain_group_assignments (domain_id, group_id) VALUES (:domain_id, :group_id)');
+$db->bind(':domain_id', $domainId);
+$db->bind(':group_id', $groupId);
+$db->execute();
+
+// Seed alert rule and incident data.
+$ruleId = Alert::createRule([
+    'name' => 'High SPF Failures',
+    'description' => 'Trigger when SPF failures exceed one.',
+    'rule_type' => 'threshold',
+    'metric' => 'spf_failures',
+    'threshold_value' => 1,
+    'threshold_operator' => '>=',
+    'time_window' => 60,
+    'domain_filter' => $domainName,
+    'group_filter' => $groupId,
+    'severity' => 'high',
+    'notification_channels' => ['email'],
+    'notification_recipients' => ['alerts@example.com'],
+    'webhook_url' => '',
+    'enabled' => 1,
+]);
+
+$db->query('INSERT INTO alert_incidents (rule_id, metric_value, threshold_value, message) VALUES (:rule_id, :metric_value, :threshold_value, :message)');
+$db->bind(':rule_id', $ruleId);
+$db->bind(':metric_value', 5);
+$db->bind(':threshold_value', 1);
+$db->bind(':message', 'Test incident message');
+$db->execute();
+
+$alertController = new AlertController();
+
+// Validate rules page renders expected controls.
+$_GET['action'] = 'rules';
+$outputRules = captureOutput(static fn() => $alertController->handleRequest());
+assertContains('Create Rule', $outputRules, 'Alert rules page should include creation button.', $failures);
+assertContains('High SPF Failures', $outputRules, 'Alert rules page should render seeded rule.', $failures);
+
+// Validate incidents page includes acknowledge control.
+$_GET['action'] = 'incidents';
+$outputIncidents = captureOutput(static fn() => $alertController->handleRequest());
+assertContains('Acknowledge', $outputIncidents, 'Incident view should include acknowledge action.', $failures);
+
+// Validate create form renders domain/group selectors.
+$_GET['action'] = 'create-rule';
+$outputCreate = captureOutput(static fn() => $alertController->handleRequest());
+assertContains('name="notification_channels[]"', $outputCreate, 'Create rule form should include notification channel checkboxes.', $failures);
+assertContains('Domain Group', $outputCreate, 'Create rule form should provide group selection.', $failures);
+
+// Prepare DMARC data to trigger alert rule.
+$reportId = insertDmarcReport($domainId, 'report-' . $timestamp);
+insertDmarcRecord($reportId, '203.0.113.10', 5, 'reject', 'fail', 'fail');
+
+$sentEmails = [];
+Mailer::setTransportOverride(static function (string $to, string $subject) use (&$sentEmails): bool {
+    $sentEmails[] = ['to' => $to, 'subject' => $subject];
+    return true;
+});
+
+$alertResults = AlertService::runAlertChecks();
+
+assertPredicate(!empty($alertResults), 'Alert service should detect a triggered incident.', $failures);
+assertTrue(!empty($sentEmails), 'Alert notifications should be attempted for triggered incidents.', $failures);
+
+$db->query('SELECT COUNT(*) as total FROM alert_incidents');
+$incidentCount = $db->single();
+assertTrue(($incidentCount['total'] ?? 0) > 0, 'Incident table should contain entries after running checks.', $failures);
+
+// Validate digest scheduling and execution.
+$sentEmails = [];
+Mailer::setTransportOverride(static function (string $to, string $subject) use (&$sentEmails): bool {
+    $sentEmails[] = ['to' => $to, 'subject' => $subject];
+    return true;
+});
+
+$scheduleId = EmailDigest::createSchedule([
+    'name' => 'Weekly Digest Test',
+    'frequency' => 'weekly',
+    'recipients' => ['digest@example.com'],
+    'domain_filter' => $domainName,
+    'group_filter' => null,
+    'enabled' => 1,
+    'next_scheduled' => date('Y-m-d H:i:s', time() - 60),
+]);
+
+$digestResults = EmailDigestService::processDueDigests();
+assertPredicate(!empty($digestResults), 'Digest service should process due schedules.', $failures);
+assertTrue(!empty($sentEmails), 'Digest processing should send email notifications.', $failures);
+
+$db->query('SELECT COUNT(*) as total FROM email_digest_logs WHERE schedule_id = :schedule_id');
+$db->bind(':schedule_id', $scheduleId);
+$logCount = $db->single();
+assertTrue(($logCount['total'] ?? 0) > 0, 'Digest logs should record send attempts.', $failures);
+
+// Exercise report email action.
+$_POST = [
+    'action' => 'send_report_email',
+    'report_id' => $reportId,
+    'recipients' => 'reports@example.com'
+];
+
+$sentEmails = [];
+Mailer::setTransportOverride(static function (string $to, string $subject) use (&$sentEmails): bool {
+    $sentEmails[] = ['to' => $to, 'subject' => $subject];
+    return true;
+});
+
+$reportsController = new ReportsController();
+$reportsController->handleSubmission();
+
+assertTrue(!empty($sentEmails), 'Report controller should dispatch an email when requested.', $failures);
+assertTrue(!empty($_SESSION['messages']), 'Report email action should add a feedback message.', $failures);
+
+Mailer::setTransportOverride(null);
+
+echo 'Alert & digest flow tests completed with ' . ($failures === 0 ? 'no failures' : $failures . ' failure(s)') . PHP_EOL;
+exit($failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
- add Spectre-based management views for alert rules, incidents, and rule creation with CSRF-aware forms
- introduce digest scheduling UI, reusable alert/digest services, cron automation, and shared email templates
- enable report email sending from the listing page and cover new flows with alert/digest/report tests

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68db464267e0832aaa10b3828e013d9d