### PR TITLE
Permanently delete processed IMAP reports

### DIFF
--- a/root/app/Services/ImapIngestionService.php
+++ b/root/app/Services/ImapIngestionService.php
@@ -113,6 +113,7 @@ class ImapIngestionService
                     if ($this->processEmail($uid)) {
                         $results['processed']++;
                         // Mark email as read/processed
+                        imap_delete($this->connection, $uid, FT_UID);
                         imap_setflag_full($this->connection, $uid, '\\Seen', ST_UID);
                     } else {
                         $results['errors']++;
@@ -123,7 +124,9 @@ class ImapIngestionService
                 }
             }
 
-            $results['messages'][] = "Processed {$results['processed']} reports with {$results['errors']} errors";
+            imap_expunge($this->connection);
+
+            $results['messages'][] = "Processed {$results['processed']} reports with {$results['errors']} errors; flagged messages were expunged";
         } catch (Exception $e) {
             $results['messages'][] = 'Error during email processing: ' . $e->getMessage();
         } finally {


### PR DESCRIPTION
## Summary
- delete processed IMAP messages after successful parsing to keep the mailbox clean
- expunge the mailbox after processing and clarify the status message for troubleshooting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db821704ec832abd5d59106da98209