### PR TITLE
Add domain-scoped threats and refine digest retries

### DIFF
--- a/root/app/Controllers/AnalyticsController.php
+++ b/root/app/Controllers/AnalyticsController.php
@@ -35,7 +35,7 @@ class AnalyticsController extends Controller
         $summaryStats = Analytics::getSummaryStatistics($startDate, $endDate, $domain);
 
         // Get top threats (IPs with most failures)
-        $topThreats = Analytics::getTopThreats($startDate, $endDate, 10);
+        $topThreats = Analytics::getTopThreats($startDate, $endDate, 10, null, $domainFilter);
 
         // Get compliance trends
         $complianceData = Analytics::getComplianceData($startDate, $endDate, $domain);

--- a/root/app/Models/PdfReport.php
+++ b/root/app/Models/PdfReport.php
@@ -143,7 +143,9 @@ class PdfReport
      */
     private static function generateTopThreatsData(string $startDate, string $endDate, string $domainFilter, ?int $groupFilter): array
     {
-        return \App\Models\Analytics::getTopThreats($startDate, $endDate, 20, $groupFilter);
+        $domain = $domainFilter !== '' ? $domainFilter : null;
+
+        return \App\Models\Analytics::getTopThreats($startDate, $endDate, 20, $groupFilter, $domain);
     }
 
     /**

--- a/root/app/Services/EmailDigestService.php
+++ b/root/app/Services/EmailDigestService.php
@@ -90,9 +90,12 @@ class EmailDigestService
                 $errorMessage
             );
 
+            $nextRunValue = $nextRun ? $nextRun->format('Y-m-d H:i:s') : null;
+
             EmailDigest::updateLastSent(
                 (int) $schedule['id'],
-                $nextRun ? $nextRun->format('Y-m-d H:i:s') : null
+                $nextRunValue,
+                $success
             );
 
             $results[] = [
@@ -102,7 +105,7 @@ class EmailDigestService
                 'failed_recipients' => $failedRecipients,
                 'start_date' => $startDate,
                 'end_date' => $endDate,
-                'next_run' => $nextRun ? $nextRun->format('Y-m-d H:i:s') : null,
+                'next_run' => $nextRunValue,
                 'message' => $errorMessage,
             ];
         }

--- a/unit/PdfReportGroupFilterTest.php
+++ b/unit/PdfReportGroupFilterTest.php
@@ -199,6 +199,15 @@ if (!empty($volumeTrends)) {
     assertEquals(10, (int) ($firstVolumeTrend['total_volume'] ?? -1), 'Volume trends should only include in-group mail', $failures);
 }
 
+$singleDomainReport = PdfReport::generateReportData($templateId, $startDate, $endDate, $domainA1, null);
+$singleDomainThreats = $singleDomainReport['sections']['top_threats'] ?? [];
+assertCountEquals(1, $singleDomainThreats, 'Domain-filtered report should only list threats for the selected domain', $failures);
+if (!empty($singleDomainThreats)) {
+    $singleThreat = $singleDomainThreats[0];
+    assertEquals('198.51.100.1', $singleThreat['source_ip'] ?? '', 'Domain-filtered threats should include the matching IP', $failures);
+    assertTrue(strpos($singleThreat['affected_domains'] ?? '', $domainA2) === false, 'Domain-filtered threats should not mention other domains', $failures);
+}
+
 $breakdown = $sections['authentication_breakdown'] ?? [];
 assertCountEquals(2, $breakdown, 'Authentication breakdown should ignore out-of-group combinations', $failures);
 foreach ($breakdown as $row) {


### PR DESCRIPTION
## Summary
- allow the analytics top threats query to accept an optional domain filter and plumb it through the dashboard and PDF report generation
- ensure email digest scheduling only advances the last_sent timestamp on successful deliveries while still planning retries for failures
- extend analytics and digest coverage to exercise the new domain filter and both successful and failed digest processing paths

## Testing
- php unit/DatabaseCompatibilityTest.php *(fails: missing /root/vendor autoload files in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3d69ba4c832ab576b71f25038209