### PR TITLE
Add DMARC policy context to reports and analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Introduced saved report filters with dedicated persistence, controller routes, UI affordances, and regression coverage.
 - Added CSV and XLSX report exports powered by the new `ReportExport` utility and accompanying unit tests.
 - Added a retention settings controller/view guarded by the new `manage_retention` permission, plus tests for the update workflow.
+- Captured DMARC policy alignment metadata, override reasoning, and authentication evidence throughout ingestion, analytics, and the report detail experience with forward- and installer-ready schema changes.
 
 ### Changed
 - Updated documentation to explain the dual Composer environments and new directory structure.

--- a/root/app/Database/Migrations/202407150003_add_dmarc_policy_context.php
+++ b/root/app/Database/Migrations/202407150003_add_dmarc_policy_context.php
@@ -1,0 +1,27 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+
+return [
+    'up' => [
+        "ALTER TABLE dmarc_aggregate_reports ADD COLUMN policy_adkim TEXT",
+        "ALTER TABLE dmarc_aggregate_reports ADD COLUMN policy_aspf TEXT",
+        "ALTER TABLE dmarc_aggregate_reports ADD COLUMN policy_p TEXT",
+        "ALTER TABLE dmarc_aggregate_reports ADD COLUMN policy_sp TEXT",
+        "ALTER TABLE dmarc_aggregate_reports ADD COLUMN policy_pct INTEGER",
+        "ALTER TABLE dmarc_aggregate_reports ADD COLUMN policy_fo TEXT",
+        "ALTER TABLE dmarc_aggregate_records ADD COLUMN policy_evaluated_reasons TEXT",
+        "ALTER TABLE dmarc_aggregate_records ADD COLUMN policy_override_reasons TEXT",
+        "ALTER TABLE dmarc_aggregate_records ADD COLUMN auth_results TEXT",
+    ],
+    'down' => [
+        'ALTER TABLE dmarc_aggregate_reports DROP COLUMN policy_adkim',
+        'ALTER TABLE dmarc_aggregate_reports DROP COLUMN policy_aspf',
+        'ALTER TABLE dmarc_aggregate_reports DROP COLUMN policy_p',
+        'ALTER TABLE dmarc_aggregate_reports DROP COLUMN policy_sp',
+        'ALTER TABLE dmarc_aggregate_reports DROP COLUMN policy_pct',
+        'ALTER TABLE dmarc_aggregate_reports DROP COLUMN policy_fo',
+        'ALTER TABLE dmarc_aggregate_records DROP COLUMN policy_evaluated_reasons',
+        'ALTER TABLE dmarc_aggregate_records DROP COLUMN policy_override_reasons',
+        'ALTER TABLE dmarc_aggregate_records DROP COLUMN auth_results',
+    ],
+];

--- a/root/app/Views/report_detail.php
+++ b/root/app/Views/report_detail.php
@@ -69,6 +69,119 @@ function formatReputationScore($score): string {
     return '<span class="' . $class . '">Score ' . $score . '</span>';
 }
 
+function renderPolicyChips(array $report): string {
+    $policies = [
+        'p' => $report['policy_p'] ?? null,
+        'sp' => $report['policy_sp'] ?? null,
+        'adkim' => $report['policy_adkim'] ?? null,
+        'aspf' => $report['policy_aspf'] ?? null,
+        'pct' => $report['policy_pct'] ?? null,
+        'fo' => $report['policy_fo'] ?? null,
+    ];
+
+    $chips = [];
+    foreach ($policies as $label => $value) {
+        if ($value === null || $value === '') {
+            continue;
+        }
+
+        $displayValue = $value;
+        if ($label === 'pct') {
+            $displayValue = (int) $value . '%';
+        }
+
+        $chips[] = '<span class="chip chip-sm mr-1"><strong class="text-uppercase">'
+            . htmlspecialchars((string) $label, ENT_QUOTES, 'UTF-8')
+            . '</strong>: '
+            . htmlspecialchars((string) $displayValue, ENT_QUOTES, 'UTF-8')
+            . '</span>';
+    }
+
+    return !empty($chips) ? implode('', $chips) : '<span class="text-gray">No published policy details</span>';
+}
+
+function renderReasonList(array $reasons): string {
+    if (empty($reasons)) {
+        return '<span class="text-gray">No details provided</span>';
+    }
+
+    $items = [];
+    foreach ($reasons as $reason) {
+        if (!is_array($reason)) {
+            continue;
+        }
+
+        $type = isset($reason['type']) && $reason['type'] !== ''
+            ? '<span class="label label-secondary label-rounded text-uppercase mr-1">'
+                . htmlspecialchars((string) $reason['type'], ENT_QUOTES, 'UTF-8')
+                . '</span>'
+            : '';
+
+        $comment = isset($reason['comment']) && $reason['comment'] !== ''
+            ? '<span class="text-gray">' . htmlspecialchars((string) $reason['comment'], ENT_QUOTES, 'UTF-8') . '</span>'
+            : '';
+
+        if ($type === '' && $comment === '') {
+            continue;
+        }
+
+        $items[] = '<li>' . $type . $comment . '</li>';
+    }
+
+    if (empty($items)) {
+        return '<span class="text-gray">No details provided</span>';
+    }
+
+    return '<ul class="reason-list mb-0">' . implode('', $items) . '</ul>';
+}
+
+function renderAuthResults(array $authResults): string {
+    if (empty($authResults)) {
+        return '<span class="text-gray">No authentication details</span>';
+    }
+
+    $segments = [];
+    foreach ($authResults as $method => $entries) {
+        if (!is_array($entries) || empty($entries)) {
+            continue;
+        }
+
+        $methodLabel = '<span class="label label-primary label-rounded text-uppercase mr-1">'
+            . htmlspecialchars((string) $method, ENT_QUOTES, 'UTF-8')
+            . '</span>';
+
+        $details = [];
+        foreach ($entries as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+
+            $chips = [];
+            foreach ($entry as $key => $value) {
+                if ($value === null || $value === '') {
+                    continue;
+                }
+
+                $chips[] = '<span class="chip chip-sm mr-1">'
+                    . htmlspecialchars((string) $key, ENT_QUOTES, 'UTF-8')
+                    . ': '
+                    . htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8')
+                    . '</span>';
+            }
+
+            if (!empty($chips)) {
+                $details[] = '<div class="mt-1">' . implode('', $chips) . '</div>';
+            }
+        }
+
+        if (!empty($details)) {
+            $segments[] = '<div class="auth-block">' . $methodLabel . implode('', $details) . '</div>';
+        }
+    }
+
+    return !empty($segments) ? implode('', $segments) : '<span class="text-gray">No authentication details</span>';
+}
+
 function renderRdapContacts(array $contacts): string {
     if (empty($contacts)) {
         return '<span class="text-gray">No published contacts</span>';
@@ -123,6 +236,35 @@ $intelMap = $this->data['ip_intelligence'] ?? [];
 .stat-label {
     font-size: 0.9rem;
     opacity: 0.9;
+}
+.policy-summary {
+    margin-top: 0.75rem;
+}
+.policy-summary .chip {
+    margin-bottom: 0.25rem;
+}
+.reason-list {
+    list-style: none;
+    padding-left: 0;
+}
+.reason-list li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.35rem;
+}
+.reason-list li:last-child {
+    margin-bottom: 0;
+}
+.auth-block {
+    margin-bottom: 0.5rem;
+}
+.auth-block:last-child {
+    margin-bottom: 0;
+}
+.auth-block .chip {
+    display: inline-block;
+    margin-bottom: 0.25rem;
 }
 .ip-group {
     border: 1px solid #e9ecef;
@@ -194,6 +336,10 @@ $intelMap = $this->data['ip_intelligence'] ?? [];
                 <br>
                 <strong>Received:</strong> <?= date('M j, Y H:i', strtotime($this->data['report']['received_at'])) ?>
             </p>
+            <div class="policy-summary">
+                <small class="text-uppercase text-light">Published Policy</small>
+                <div class="mt-1"><?= renderPolicyChips($this->data['report']); ?></div>
+            </div>
         </div>
         <div class="column col-12 col-lg-4 mt-2 mt-lg-0">
             <div class="stat-box">
@@ -243,6 +389,110 @@ $intelMap = $this->data['ip_intelligence'] ?? [];
             <div class="card-body">
                 <div class="h5"><?= formatAuthResult($this->data['summary']['spf_pass_count'], $this->data['summary']['total_volume']) ?></div>
                 <small class="text-gray">SPF Pass Rate</small>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php
+    $summary = $this->data['summary'];
+    $totalVolume = max(0, (int) ($summary['total_volume'] ?? 0));
+    $reasonVolume = (int) ($summary['policy_evaluated_reason_volume'] ?? 0);
+    $overrideVolume = (int) ($summary['policy_override_volume'] ?? 0);
+    $authVolume = (int) ($summary['auth_results_volume'] ?? 0);
+    $reasonPercent = $totalVolume > 0 ? (int) round(($reasonVolume / $totalVolume) * 100) : 0;
+    $overridePercent = $totalVolume > 0 ? (int) round(($overrideVolume / $totalVolume) * 100) : 0;
+    $authPercent = $totalVolume > 0 ? (int) round(($authVolume / $totalVolume) * 100) : 0;
+?>
+
+<div class="columns mb-2">
+    <div class="column col-12 col-sm-6 col-lg-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <div class="h5"><span class="chip chip-sm"><?= number_format($reasonVolume) ?> (<?= $reasonPercent ?>%)</span></div>
+                <small class="text-gray">Policy Evaluation Flags</small>
+            </div>
+        </div>
+    </div>
+    <div class="column col-12 col-sm-6 col-lg-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <div class="h5"><span class="chip chip-sm"><?= number_format($overrideVolume) ?> (<?= $overridePercent ?>%)</span></div>
+                <small class="text-gray">Overrides Applied</small>
+            </div>
+        </div>
+    </div>
+    <div class="column col-12 col-sm-6 col-lg-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <div class="h5"><span class="chip chip-sm"><?= number_format($authVolume) ?> (<?= $authPercent ?>%)</span></div>
+                <small class="text-gray">Auth Evidence Provided</small>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="columns mb-2">
+    <div class="column col-12 col-lg-6">
+        <div class="card">
+            <div class="card-header">
+                <div class="card-title h5">
+                    <i class="icon icon-flag mr-1"></i>
+                    Policy Evaluation Reasons
+                </div>
+            </div>
+            <div class="card-body">
+                <?php if (!empty($summary['policy_evaluated_reason_breakdown'])): ?>
+                    <ul class="menu menu-nav mb-0">
+                        <?php foreach ($summary['policy_evaluated_reason_breakdown'] as $label => $count): ?>
+                            <li class="menu-item d-flex justify-content-between align-items-center">
+                                <span><?= htmlspecialchars($label === 'unspecified' ? 'Unspecified' : (string) $label, ENT_QUOTES, 'UTF-8') ?></span>
+                                <span class="chip chip-sm"><?= number_format($count) ?></span>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                <?php else: ?>
+                    <span class="text-gray">No policy evaluation reasons provided.</span>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+    <div class="column col-12 col-lg-6">
+        <div class="card">
+            <div class="card-header">
+                <div class="card-title h5">
+                    <i class="icon icon-refresh mr-1"></i>
+                    Overrides &amp; Auth Context
+                </div>
+            </div>
+            <div class="card-body">
+                <h6 class="text-uppercase text-gray mb-1">Overrides</h6>
+                <?php if (!empty($summary['policy_override_breakdown'])): ?>
+                    <ul class="menu menu-nav mb-2">
+                        <?php foreach ($summary['policy_override_breakdown'] as $label => $count): ?>
+                            <li class="menu-item d-flex justify-content-between align-items-center">
+                                <span><?= htmlspecialchars($label === 'unspecified' ? 'Unspecified' : (string) $label, ENT_QUOTES, 'UTF-8') ?></span>
+                                <span class="chip chip-sm"><?= number_format($count) ?></span>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                <?php else: ?>
+                    <p class="text-gray mb-2">No policy overrides recorded.</p>
+                <?php endif; ?>
+
+                <h6 class="text-uppercase text-gray mb-1">Authentication Methods</h6>
+                <?php if (!empty($summary['auth_result_breakdown'])): ?>
+                    <ul class="menu menu-nav mb-0">
+                        <?php foreach ($summary['auth_result_breakdown'] as $method => $count): ?>
+                            <li class="menu-item d-flex justify-content-between align-items-center">
+                                <span><?= htmlspecialchars((string) $method, ENT_QUOTES, 'UTF-8') ?></span>
+                                <span class="chip chip-sm"><?= number_format($count) ?></span>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                <?php else: ?>
+                    <span class="text-gray">No authentication breakdown was supplied.</span>
+                <?php endif; ?>
             </div>
         </div>
     </div>
@@ -385,6 +635,28 @@ $intelMap = $this->data['ip_intelligence'] ?? [];
                                         <?php endif; ?>
                                     </div>
                                 </div>
+                                <?php if (!empty($record['policy_evaluated_reasons']) || !empty($record['policy_override_reasons']) || !empty($record['auth_results'])): ?>
+                                    <div class="columns mt-1">
+                                        <?php if (!empty($record['policy_evaluated_reasons'])): ?>
+                                            <div class="column col-12 col-lg-4">
+                                                <small class="text-gray text-uppercase text-tiny">Evaluation Reasons</small>
+                                                <?= renderReasonList($record['policy_evaluated_reasons']); ?>
+                                            </div>
+                                        <?php endif; ?>
+                                        <?php if (!empty($record['policy_override_reasons'])): ?>
+                                            <div class="column col-12 col-lg-4">
+                                                <small class="text-gray text-uppercase text-tiny">Overrides</small>
+                                                <?= renderReasonList($record['policy_override_reasons']); ?>
+                                            </div>
+                                        <?php endif; ?>
+                                        <?php if (!empty($record['auth_results'])): ?>
+                                            <div class="column col-12 col-lg-4">
+                                                <small class="text-gray text-uppercase text-tiny">Auth Results</small>
+                                                <?= renderAuthResults($record['auth_results']); ?>
+                                            </div>
+                                        <?php endif; ?>
+                                    </div>
+                                <?php endif; ?>
                             </div>
                         <?php endforeach; ?>
                     </div>

--- a/root/install/install.sql
+++ b/root/install/install.sql
@@ -59,6 +59,12 @@ CREATE TABLE dmarc_aggregate_reports (
     date_range_begin INTEGER NOT NULL,
     date_range_end INTEGER NOT NULL,
     received_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    policy_adkim TEXT,
+    policy_aspf TEXT,
+    policy_p TEXT,
+    policy_sp TEXT,
+    policy_pct INTEGER,
+    policy_fo TEXT,
     raw_xml TEXT,
     processed INTEGER DEFAULT 0,
     FOREIGN KEY (domain_id) REFERENCES domains(id) ON DELETE CASCADE
@@ -79,6 +85,9 @@ CREATE TABLE dmarc_aggregate_records (
     header_from TEXT,
     envelope_from TEXT,
     envelope_to TEXT,
+    policy_evaluated_reasons TEXT,
+    policy_override_reasons TEXT,
+    auth_results TEXT,
     FOREIGN KEY (report_id) REFERENCES dmarc_aggregate_reports(id) ON DELETE CASCADE
 );
 

--- a/unit/DmarcReportPersistenceTest.php
+++ b/unit/DmarcReportPersistenceTest.php
@@ -1,0 +1,92 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+
+declare(strict_types=1);
+
+if (!defined('PHPUNIT_RUNNING')) {
+    define('PHPUNIT_RUNNING', true);
+}
+
+$autoloadPath = __DIR__ . '/../root/vendor/autoload.php';
+if (!is_file($autoloadPath)) {
+    echo 'DMARC report persistence tests skipped: composer autoloader not available.' . PHP_EOL;
+    exit(0);
+}
+
+require $autoloadPath;
+require __DIR__ . '/../root/config.php';
+require __DIR__ . '/TestHelpers.php';
+
+use App\Core\DatabaseManager;
+use App\Models\DmarcReport;
+use App\Utilities\DmarcParser;
+use function TestHelpers\assertCountEquals;
+use function TestHelpers\assertEquals;
+use function TestHelpers\assertTrue;
+
+$failures = 0;
+$db = DatabaseManager::getInstance();
+
+\App\Core\SessionManager::getInstance()->start();
+\App\Core\SessionManager::getInstance()->set('logged_in', true);
+\App\Core\SessionManager::getInstance()->set('user_role', \App\Core\RBACManager::ROLE_APP_ADMIN);
+\App\Core\SessionManager::getInstance()->set('username', 'dmarc-report-persistence');
+
+$fixturePath = __DIR__ . '/fixtures/dmarc/aggregate-sample.xml';
+$xml = file_get_contents($fixturePath);
+assertTrue($xml !== false, 'Aggregate fixture should be readable for persistence tests.', $failures);
+
+if ($xml !== false) {
+    $reportData = DmarcParser::parseAggregateReport($xml);
+
+    $uniqueDomain = 'aggregate-' . bin2hex(random_bytes(4)) . '.example';
+    $reportData['policy_published_domain'] = $uniqueDomain;
+    foreach ($reportData['records'] as &$record) {
+        if (!isset($record['header_from']) || $record['header_from'] === null) {
+            $record['header_from'] = $uniqueDomain;
+        }
+    }
+    unset($record);
+
+    $reportId = DmarcReport::storeAggregateReport($reportData);
+    assertTrue($reportId > 0, 'Aggregate report should persist and yield an ID.', $failures);
+
+    if ($reportId > 0) {
+        $stored = DmarcReport::storeAggregateRecords($reportId, $reportData['records']);
+        assertTrue($stored, 'Aggregate records should persist successfully.', $failures);
+
+        $details = DmarcReport::getReportDetails($reportId);
+        assertTrue(is_array($details), 'Stored report details should be retrievable.', $failures);
+        if (is_array($details)) {
+            assertEquals('r', $details['policy_adkim'] ?? null, 'Stored report should capture adkim.', $failures);
+            assertEquals('none', $details['policy_p'] ?? null, 'Stored report should capture policy p.', $failures);
+            assertEquals(100, $details['policy_pct'] ?? null, 'Stored report should capture policy pct.', $failures);
+            assertEquals('1', $details['policy_fo'] ?? null, 'Stored report should capture policy fo.', $failures);
+        }
+
+        $records = DmarcReport::getAggregateRecords($reportId);
+        assertCountEquals(1, $records, 'Persisted records should be retrievable.', $failures);
+
+        if (!empty($records)) {
+            $record = $records[0];
+            assertEquals('forwarded', $record['policy_evaluated_reasons'][0]['type'] ?? null, 'Persisted record should retain evaluation reason.', $failures);
+            assertEquals('local_policy', $record['policy_override_reasons'][0]['type'] ?? null, 'Persisted record should retain override reason.', $failures);
+            assertEquals('selector1', $record['auth_results']['dkim'][0]['selector'] ?? null, 'Persisted record should retain DKIM auth result.', $failures);
+        }
+
+        $db->query('DELETE FROM dmarc_aggregate_records WHERE report_id = :report_id');
+        $db->bind(':report_id', $reportId);
+        $db->execute();
+
+        $db->query('DELETE FROM dmarc_aggregate_reports WHERE id = :report_id');
+        $db->bind(':report_id', $reportId);
+        $db->execute();
+
+        $db->query('DELETE FROM domains WHERE domain = :domain');
+        $db->bind(':domain', $uniqueDomain);
+        $db->execute();
+    }
+}
+
+echo 'DMARC report persistence tests completed with ' . ($failures === 0 ? 'no failures' : $failures . ' failure(s)') . PHP_EOL;
+exit($failures === 0 ? 0 : 1);

--- a/unit/fixtures/dmarc/aggregate-sample.xml
+++ b/unit/fixtures/dmarc/aggregate-sample.xml
@@ -16,6 +16,7 @@
         <p>none</p>
         <sp>none</sp>
         <pct>100</pct>
+        <fo>1</fo>
     </policy_published>
     <record>
         <row>
@@ -24,7 +25,15 @@
             <policy_evaluated>
                 <disposition>none</disposition>
                 <dkim>pass</dkim>
-                <spf>pass</spf>
+                <spf>fail</spf>
+                <reason>
+                    <type>forwarded</type>
+                    <comment>Trusted forwarder sample</comment>
+                </reason>
+                <policy_override>
+                    <type>local_policy</type>
+                    <comment>Allowing reporting domain</comment>
+                </policy_override>
             </policy_evaluated>
         </row>
         <identifiers>
@@ -32,5 +41,17 @@
             <envelope_from>mail.aggregate.example</envelope_from>
             <envelope_to>postmaster@example.org</envelope_to>
         </identifiers>
+        <auth_results>
+            <dkim>
+                <domain>aggregate.example</domain>
+                <selector>selector1</selector>
+                <result>pass</result>
+            </dkim>
+            <spf>
+                <domain>aggregate.example</domain>
+                <scope>mfrom</scope>
+                <result>fail</result>
+            </spf>
+        </auth_results>
     </record>
 </feedback>


### PR DESCRIPTION
## Summary
- extend DMARC aggregate parsing to capture published policy settings, per-record override reasons, and authentication results
- persist the new policy metadata via schema updates, migrations, and model helpers, and surface it through analytics and the report detail UI
- add fixtures and regression tests (including a persistence smoke test) covering the richer data flow

## Testing
- php unit/DmarcParserTest.php
- php unit/DmarcReportPersistenceTest.php *(skipped: composer autoloader not available)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd56fdfb0832aad378ccfa45f7db7